### PR TITLE
Add ohttp sub-package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/moorara/observer
 go 1.14
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/prometheus/client_golang v1.6.0
 	github.com/stretchr/testify v1.5.1
 	go.opentelemetry.io/otel v0.4.3

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/ohttp/client.go
+++ b/ohttp/client.go
@@ -1,0 +1,229 @@
+package ohttp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/moorara/observer"
+	"go.opentelemetry.io/otel/api/core"
+	"go.opentelemetry.io/otel/api/correlation"
+	"go.opentelemetry.io/otel/api/key"
+	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/api/unit"
+	"go.opentelemetry.io/otel/plugin/httptrace"
+	"go.uber.org/zap"
+)
+
+// ClientOptions are optional configurations for creating a client.
+type ClientOptions struct {
+	// Whether or not to log successful requests at debug level (the default is at info level).
+	LogAtDebugLevel bool
+}
+
+// Client-side instruments for metrics.
+type clientInstruments struct {
+	reqCounter  metric.Int64Counter
+	reqDuration metric.Int64Measure
+}
+
+func newClientInstruments(meter metric.Meter) *clientInstruments {
+	mustMeter := metric.Must(meter)
+
+	return &clientInstruments{
+		reqCounter: mustMeter.NewInt64Counter(
+			"outgoing_http_requests_total",
+			metric.WithDescription("The total number of outgoing requests (client-side)"),
+			metric.WithUnit(unit.Dimensionless),
+			metric.WithLibraryName(libraryName),
+		),
+		reqDuration: mustMeter.NewInt64Measure(
+			"outgoing_http_requests_duration",
+			metric.WithDescription("The duration of outgoing requests in seconds (client-side)"),
+			metric.WithUnit(unit.Milliseconds),
+			metric.WithLibraryName(libraryName),
+		),
+	}
+}
+
+// Client is a drop-in replacement for the standard http.Client.
+// It is an observable http client with logging, metrics, and tracing.
+type Client struct {
+	opts        ClientOptions
+	client      *http.Client
+	observer    *observer.Observer
+	instruments *clientInstruments
+}
+
+// NewClient creates a new observable http client.
+func NewClient(client *http.Client, observer *observer.Observer, opts ClientOptions) *Client {
+	instruments := newClientInstruments(observer.Meter())
+
+	return &Client{
+		opts:        opts,
+		client:      client,
+		observer:    observer,
+		instruments: instruments,
+	}
+}
+
+// CloseIdleConnections is the observable counterpart of standard http Client.CloseIdleConnections.
+func (c *Client) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}
+
+// Get is the observable counterpart of standard http Client.Get.
+// Using this method, request context (UUID and trace) will be auto-generated.
+// If you have a context for the request, consider using the Do method.
+func (c *Client) Get(url string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.client.Do(req)
+}
+
+// Head is the observable counterpart of standard http Client.Head.
+// Using this method, request context (UUID and trace) will be auto-generated.
+// If you have a context for the request, consider using the Do method.
+func (c *Client) Head(url string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.client.Do(req)
+}
+
+// Post is the observable counterpart of standard http Client.Post.
+// Using this method, request context (UUID and trace) will be auto-generated.
+// If you have a context for the request, consider using the Do method.
+func (c *Client) Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", contentType)
+
+	return c.client.Do(req)
+}
+
+// PostForm is the observable counterpart of standard http Client.PostForm.
+// Using this method, request context (UUID and trace) will be auto-generated.
+// If you have a context for the request, consider using the Do method.
+func (c *Client) PostForm(url string, data url.Values) (resp *http.Response, err error) {
+	contentType := "application/x-www-form-urlencoded"
+	body := strings.NewReader(data.Encode())
+
+	return c.Post(url, contentType, body)
+}
+
+// Do is the observable counterpart of standard http Client.Do.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	startTime := time.Now()
+
+	kind := "client"
+	protocol := req.Proto
+	method := req.Method
+	url := req.URL.Path
+	ctx := req.Context()
+
+	// Make sure the request has a UUID
+	requestUUID, ok := observer.UUIDFromContext(ctx)
+	if !ok || requestUUID == "" {
+		requestUUID = uuid.New().String()
+	}
+	req.Header.Set(requestUUIDHeader, requestUUID)
+
+	// Create a new correlation context
+	ctx = correlation.NewContext(ctx,
+		key.String("req.uuid", requestUUID),
+	)
+
+	// Start a new span
+	ctx, span := c.observer.Tracer().Start(ctx,
+		"client-request",
+		trace.WithSpanKind(trace.SpanKindClient),
+	)
+	defer span.End()
+
+	// Inject the correlation context and the span context into the request
+	ctx, req = httptrace.W3C(ctx, req)
+	httptrace.Inject(ctx, req)
+
+	// Make the call
+	resp, err := c.client.Do(req)
+
+	duration := time.Since(startTime).Milliseconds()
+
+	var statusCode int
+	var statusClass string
+
+	if err != nil {
+		statusCode = -1
+		statusClass = ""
+	} else {
+		statusCode = resp.StatusCode
+		statusClass = fmt.Sprintf("%dxx", statusCode/100)
+	}
+
+	// Report metrics
+	c.observer.Meter().RecordBatch(ctx,
+		[]core.KeyValue{
+			key.String("protocol", protocol),
+			key.String("method", method),
+			key.String("url", url),
+			key.Int("status_code", statusCode),
+			key.String("status_class", statusClass),
+		},
+		c.instruments.reqCounter.Measurement(1),
+		c.instruments.reqDuration.Measurement(duration),
+	)
+
+	// Report logs
+	logger := c.observer.Logger()
+	message := fmt.Sprintf("%s %s %d %dms", method, url, statusCode, duration)
+	fields := []zap.Field{
+		zap.String("req.uuid", requestUUID),
+		zap.String("req.kind", kind),
+		zap.String("req.protocol", protocol),
+		zap.String("req.method", method),
+		zap.String("req.url", url),
+		zap.Int("resp.statusCode", statusCode),
+		zap.String("resp.statusClass", statusClass),
+		zap.Int64("resp.duration", duration),
+	}
+
+	// Determine the log level based on the result
+	switch {
+	case statusCode >= 500:
+		logger.Error(message, fields...)
+	case statusCode >= 400:
+		logger.Warn(message, fields...)
+	case statusCode >= 100:
+		fallthrough
+	default:
+		if c.opts.LogAtDebugLevel {
+			logger.Debug(message, fields...)
+		} else {
+			logger.Info(message, fields...)
+		}
+	}
+
+	// Report the span
+	span.SetAttributes(
+		key.String("protocol", protocol),
+		key.String("method", method),
+		key.String("url", url),
+		key.Int("status_code", statusCode),
+	)
+
+	return resp, err
+}

--- a/ohttp/client_test.go
+++ b/ohttp/client_test.go
@@ -1,0 +1,1 @@
+package ohttp

--- a/ohttp/http.go
+++ b/ohttp/http.go
@@ -1,0 +1,36 @@
+package ohttp
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	libraryName       = "observer"
+	requestUUIDHeader = "Request-UUID"
+)
+
+// responseWriter extends the standard http.ResponseWriter.
+type responseWriter struct {
+	http.ResponseWriter
+	StatusCode  int
+	StatusClass string
+}
+
+// NewResponseWriter creates a new response writer.
+func newResponseWriter(rw http.ResponseWriter) *responseWriter {
+	return &responseWriter{
+		ResponseWriter: rw,
+	}
+}
+
+// WriteHeader overrides the implementation of http.WriteHeader.
+func (r *responseWriter) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+
+	// Only capture the first value
+	if r.StatusCode == 0 {
+		r.StatusCode = statusCode
+		r.StatusClass = fmt.Sprintf("%dxx", statusCode/100)
+	}
+}

--- a/ohttp/http_test.go
+++ b/ohttp/http_test.go
@@ -1,0 +1,52 @@
+package ohttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponseWriter(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		statusClass string
+	}{
+		{"200", 101, "1xx"},
+		{"200", 200, "2xx"},
+		{"201", 201, "2xx"},
+		{"201", 202, "2xx"},
+		{"300", 300, "3xx"},
+		{"400", 400, "4xx"},
+		{"400", 403, "4xx"},
+		{"404", 404, "4xx"},
+		{"400", 409, "4xx"},
+		{"500", 500, "5xx"},
+		{"500", 501, "5xx"},
+		{"502", 502, "5xx"},
+		{"500", 503, "5xx"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}
+
+			middleware := func(w http.ResponseWriter, r *http.Request) {
+				rw := newResponseWriter(w)
+				handler(rw, r)
+
+				assert.Equal(t, tc.statusCode, rw.StatusCode)
+				assert.Equal(t, tc.statusClass, rw.StatusClass)
+			}
+
+			r := httptest.NewRequest("GET", "/", nil)
+			w := httptest.NewRecorder()
+
+			middleware(w, r)
+		})
+	}
+}

--- a/ohttp/server.go
+++ b/ohttp/server.go
@@ -1,0 +1,175 @@
+package ohttp
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/moorara/observer"
+	"go.opentelemetry.io/otel/api/core"
+	"go.opentelemetry.io/otel/api/correlation"
+	"go.opentelemetry.io/otel/api/key"
+	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/api/unit"
+	"go.opentelemetry.io/otel/plugin/httptrace"
+	"go.uber.org/zap"
+)
+
+// MiddlewareOptions are optional configurations for creating a server middleware.
+type MiddlewareOptions struct {
+	// Whether or not to log successful requests at debug level (the default is at info level).
+	LogAtDebugLevel bool
+}
+
+// Server-side instruments for metrics.
+type serverInstruments struct {
+	reqCounter  metric.Int64Counter
+	reqDuration metric.Int64Measure
+}
+
+func newServerInstruments(meter metric.Meter) *serverInstruments {
+	mustMeter := metric.Must(meter)
+
+	return &serverInstruments{
+		reqCounter: mustMeter.NewInt64Counter(
+			"incoming_http_requests_total",
+			metric.WithDescription("The total number of incoming requests (server-side)"),
+			metric.WithUnit(unit.Dimensionless),
+			metric.WithLibraryName(libraryName),
+		),
+		reqDuration: mustMeter.NewInt64Measure(
+			"incoming_http_requests_duration",
+			metric.WithDescription("The duration of incoming requests in milliseconds (server-side)"),
+			metric.WithUnit(unit.Milliseconds),
+			metric.WithLibraryName(libraryName),
+		),
+	}
+}
+
+// Middleware creates observable http handlers with logging, metrics, and tracing.
+type Middleware struct {
+	opts        MiddlewareOptions
+	observer    *observer.Observer
+	instruments *serverInstruments
+}
+
+// NewMiddleware creates a new observable http middleware
+func NewMiddleware(observer *observer.Observer, opts MiddlewareOptions) *Middleware {
+	instruments := newServerInstruments(observer.Meter())
+
+	return &Middleware{
+		opts:        opts,
+		observer:    observer,
+		instruments: instruments,
+	}
+}
+
+// GetHandlerFunc wraps an existing http handler function and returns a new observable handler function.
+// This can be used for making http handlers observable via logging, metrics, tracing, etc.
+func (m *Middleware) GetHandlerFunc(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+
+		kind := "server"
+		protocol := r.Proto
+		method := r.Method
+		url := r.URL.Path
+		ctx := r.Context()
+
+		// Make sure the request has a UUID
+		requestUUID := r.Header.Get(requestUUIDHeader)
+		if requestUUID == "" {
+			requestUUID = uuid.New().String()
+			r.Header.Set(requestUUIDHeader, requestUUID)
+		}
+
+		// Extract correlation context entries and parent span context if any
+		// The first return value is a list of http attributes for the request
+		_, entries, spanContext := httptrace.Extract(ctx, r)
+
+		// Create a new correlation context with the extracted entries and new ones
+		entries = append(entries,
+			key.String("req.uuid", requestUUID),
+		)
+		ctx = correlation.NewContext(ctx, entries...)
+
+		// Start a new span
+		ctx = trace.ContextWithRemoteSpanContext(ctx, spanContext)
+		ctx, span := m.observer.Tracer().Start(ctx,
+			"server-request",
+			trace.WithSpanKind(trace.SpanKindServer),
+		)
+		defer span.End()
+
+		// Create a contextualized logger
+		logger := m.observer.Logger().With(
+			zap.String("req.uuid", requestUUID),
+			zap.String("req.kind", kind),
+			zap.String("req.protocol", protocol),
+			zap.String("req.method", method),
+			zap.String("req.url", url),
+		)
+
+		// Augment the request context
+		ctx = observer.ContextWithUUID(ctx, requestUUID)
+		ctx = observer.ContextWithLogger(ctx, logger)
+		req := r.WithContext(ctx)
+
+		// Create a wrapped response writer, so we can know about the response
+		rw := newResponseWriter(w)
+
+		// Call the next http handler function
+		next(rw, req)
+
+		duration := time.Since(startTime).Milliseconds()
+		statusCode := rw.StatusCode
+		statusClass := rw.StatusClass
+
+		// Report metrics
+		m.observer.Meter().RecordBatch(ctx,
+			[]core.KeyValue{
+				key.String("protocol", protocol),
+				key.String("method", method),
+				key.String("url", url),
+				key.Int("status_code", statusCode),
+				key.String("status_class", statusClass),
+			},
+			m.instruments.reqCounter.Measurement(1),
+			m.instruments.reqDuration.Measurement(duration),
+		)
+
+		// Report logs
+		message := fmt.Sprintf("%s %s %d %dms", method, url, statusCode, duration)
+		fields := []zap.Field{
+			zap.Int("resp.statusCode", statusCode),
+			zap.String("resp.statusClass", statusClass),
+			zap.Int64("resp.duration", duration),
+		}
+
+		// Determine the log level based on the result
+		switch {
+		case statusCode >= 500:
+			logger.Error(message, fields...)
+		case statusCode >= 400:
+			logger.Warn(message, fields...)
+		case statusCode >= 100:
+			fallthrough
+		default:
+			if m.opts.LogAtDebugLevel {
+				logger.Debug(message, fields...)
+			} else {
+				logger.Info(message, fields...)
+			}
+		}
+
+		// Report the span
+		span.SetAttributes(
+			key.String("protocol", protocol),
+			key.String("method", method),
+			key.String("url", url),
+			key.Int("status_code", statusCode),
+		)
+	}
+}

--- a/ohttp/server_test.go
+++ b/ohttp/server_test.go
@@ -1,0 +1,1 @@
+package ohttp


### PR DESCRIPTION
## Description

  - [x] Adding `ohttp` package for enabling observability for http servers and clients

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [ ] Unit tests are provided for the new change
