### PR TITLE
Add request id and client name to response headers

### DIFF
--- a/ogrpc/client.go
+++ b/ogrpc/client.go
@@ -129,9 +129,10 @@ func (i *ClientInterceptor) unaryInterceptor(ctx context.Context, fullMethod str
 		md = metadata.New(nil)
 	}
 
-	// Propagate grpc request metadata
+	// Propagate request metadata by adding them to outgoing grpc request metadata
 	md.Set(requestUUIDKey, requestUUID)
 	md.Set(clientNameKey, i.observer.Name())
+	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Create a new correlation context
 	ctx = correlation.NewContext(ctx,
@@ -264,7 +265,7 @@ func (i *ClientInterceptor) streamInterceptor(ctx context.Context, desc *grpc.St
 		md = metadata.New(nil)
 	}
 
-	// Propagate grpc request metadata
+	// Propagate request metadata by adding them to outgoing grpc request metadata
 	md.Set(requestUUIDKey, requestUUID)
 	md.Set(clientNameKey, i.observer.Name())
 	ctx = metadata.NewOutgoingContext(ctx, md)

--- a/ogrpc/example/client/main.go
+++ b/ogrpc/example/client/main.go
@@ -12,159 +12,13 @@ import (
 	"github.com/moorara/observer/ogrpc/example/zonePB"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
 	httpPort   = ":9002"
 	grpcServer = "localhost:9000"
 )
-
-func getContainingZone(client zonePB.ZoneManagerClient) {
-	// A random delay between 1s to 5s
-	d := 1 + rand.Intn(4)
-	time.Sleep(time.Duration(d) * time.Second)
-
-	ctx := context.Background()
-	stream, err := client.GetContainingZone(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	locations := []*zonePB.Location{
-		{
-			Latitude:  43.662892,
-			Longitude: -79.395684,
-		},
-		{
-			Latitude:  43.658776,
-			Longitude: -79.379327,
-		},
-	}
-
-	for _, loc := range locations {
-		err := stream.Send(loc)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	_, err = stream.CloseAndRecv()
-	if err != nil {
-		panic(err)
-	}
-}
-
-func getPlacesInZone(client zonePB.ZoneManagerClient) {
-	// A random delay between 1s to 5s
-	d := 1 + rand.Intn(4)
-	time.Sleep(time.Duration(d) * time.Second)
-
-	ctx := context.Background()
-	zone := &zonePB.Zone{
-		Location: &zonePB.Location{
-			Latitude:  43.645844,
-			Longitude: -79.379742,
-		},
-		Radius: 1200,
-	}
-
-	_, err := client.GetPlacesInZone(ctx, zone)
-	if err != nil {
-		panic(err)
-	}
-}
-
-func getUsersInZone(client zonePB.ZoneManagerClient) {
-	// A random delay between 1s to 5s
-	d := 1 + rand.Intn(4)
-	time.Sleep(time.Duration(d) * time.Second)
-
-	ctx := context.Background()
-	zone := &zonePB.Zone{
-		Location: &zonePB.Location{
-			Latitude:  43.645844,
-			Longitude: -79.379742,
-		},
-		Radius: 1200,
-	}
-
-	stream, err := client.GetUsersInZone(ctx, zone)
-	if err != nil {
-		panic(err)
-	}
-
-	for {
-		_, err := stream.Recv()
-		if err != nil && err != io.EOF {
-			panic(err)
-		}
-
-		if err == io.EOF {
-			return
-		}
-	}
-}
-
-func getUsersInZones(client zonePB.ZoneManagerClient) {
-	// A random delay between 1s to 5s
-	d := 1 + rand.Intn(4)
-	time.Sleep(time.Duration(d) * time.Second)
-
-	ctx := context.Background()
-	zones := []*zonePB.Zone{
-		{
-			Location: &zonePB.Location{
-				Latitude:  45.424688,
-				Longitude: -75.699565,
-			},
-			Radius: 1500,
-		},
-		{
-			Location: &zonePB.Location{
-				Latitude:  43.472920,
-				Longitude: -80.542378,
-			},
-			Radius: 1000,
-		},
-	}
-
-	stream, err := client.GetUsersInZones(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	waitc := make(chan struct{})
-
-	// Receiving
-	go func() {
-		for {
-			_, err := stream.Recv()
-			if err != nil && err != io.EOF {
-				panic(err)
-			}
-
-			if err == io.EOF {
-				close(waitc)
-				return
-			}
-		}
-	}()
-
-	// Sending
-	for _, zone := range zones {
-		err := stream.Send(zone)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	err = stream.CloseSend()
-	if err != nil {
-		panic(err)
-	}
-
-	<-waitc
-}
 
 func main() {
 	// Creating a new Observer and set it as the singleton
@@ -203,4 +57,138 @@ func main() {
 		getUsersInZone(client)
 		getUsersInZones(client)
 	}
+}
+
+func getContainingZone(client zonePB.ZoneManagerClient) {
+	// A random delay between 1s to 5s
+	d := 1 + rand.Intn(4)
+	time.Sleep(time.Duration(d) * time.Second)
+
+	ctx := context.Background()
+
+	header := new(metadata.MD)
+	stream, err := client.GetContainingZone(ctx, grpc.Header(header))
+	if err != nil {
+		panic(err)
+	}
+
+	locations := []*zonePB.Location{
+		{Latitude: 43.662892, Longitude: -79.395684},
+		{Latitude: 43.658776, Longitude: -79.379327},
+	}
+
+	for _, loc := range locations {
+		err := stream.Send(loc)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	_, err = stream.CloseAndRecv()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getPlacesInZone(client zonePB.ZoneManagerClient) {
+	// A random delay between 1s to 5s
+	d := 1 + rand.Intn(4)
+	time.Sleep(time.Duration(d) * time.Second)
+
+	ctx := context.Background()
+	zone := &zonePB.Zone{
+		Location: &zonePB.Location{Latitude: 43.645844, Longitude: -79.379742},
+		Radius:   1200,
+	}
+
+	header := new(metadata.MD)
+	_, err := client.GetPlacesInZone(ctx, zone, grpc.Header(header))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getUsersInZone(client zonePB.ZoneManagerClient) {
+	// A random delay between 1s to 5s
+	d := 1 + rand.Intn(4)
+	time.Sleep(time.Duration(d) * time.Second)
+
+	ctx := context.Background()
+	zone := &zonePB.Zone{
+		Location: &zonePB.Location{Latitude: 43.645844, Longitude: -79.379742},
+		Radius:   1200,
+	}
+
+	header := new(metadata.MD)
+	stream, err := client.GetUsersInZone(ctx, zone, grpc.Header(header))
+	if err != nil {
+		panic(err)
+	}
+
+	for {
+		_, err := stream.Recv()
+		if err != nil && err != io.EOF {
+			panic(err)
+		}
+
+		if err == io.EOF {
+			return
+		}
+	}
+}
+
+func getUsersInZones(client zonePB.ZoneManagerClient) {
+	// A random delay between 1s to 5s
+	d := 1 + rand.Intn(4)
+	time.Sleep(time.Duration(d) * time.Second)
+
+	ctx := context.Background()
+	zones := []*zonePB.Zone{
+		{
+			Location: &zonePB.Location{Latitude: 45.424688, Longitude: -75.699565},
+			Radius:   1500,
+		},
+		{
+			Location: &zonePB.Location{Latitude: 43.472920, Longitude: -80.542378},
+			Radius:   1000,
+		},
+	}
+
+	header := new(metadata.MD)
+	stream, err := client.GetUsersInZones(ctx, grpc.Header(header))
+	if err != nil {
+		panic(err)
+	}
+
+	waitc := make(chan struct{})
+
+	// Receiving
+	go func() {
+		for {
+			_, err := stream.Recv()
+			if err != nil && err != io.EOF {
+				panic(err)
+			}
+
+			if err == io.EOF {
+				close(waitc)
+				return
+			}
+		}
+	}()
+
+	// Sending
+	for _, zone := range zones {
+		err := stream.Send(zone)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	err = stream.CloseSend()
+	if err != nil {
+		panic(err)
+	}
+
+	<-waitc
 }

--- a/ogrpc/server.go
+++ b/ogrpc/server.go
@@ -162,6 +162,13 @@ func (i *ServerInterceptor) unaryInterceptor(ctx context.Context, req interface{
 		clientName = vals[0]
 	}
 
+	// Propagate request metadata by adding them to outgoing grpc response metadata
+	header := metadata.New(map[string]string{
+		requestUUIDKey: requestUUID,
+		clientNameKey:  clientName,
+	})
+	_ = grpc.SendHeader(ctx, header)
+
 	// Extract correlation context from the grpc metadata
 	ctx = propagation.ExtractHTTP(ctx, global.Propagators(), &metadataSupplier{md: &md})
 
@@ -331,6 +338,13 @@ func (i *ServerInterceptor) streamInterceptor(srv interface{}, ss grpc.ServerStr
 	if vals := md.Get(clientNameKey); len(vals) > 0 {
 		clientName = vals[0]
 	}
+
+	// Propagate request metadata by adding them to outgoing grpc response metadata
+	header := metadata.New(map[string]string{
+		requestUUIDKey: requestUUID,
+		clientNameKey:  clientName,
+	})
+	_ = ss.SendHeader(header)
 
 	// Extract correlation context from the grpc metadata
 	ctx = propagation.ExtractHTTP(ctx, global.Propagators(), &metadataSupplier{md: &md})

--- a/ohttp/client.go
+++ b/ohttp/client.go
@@ -153,7 +153,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		requestUUID = uuid.New().String()
 	}
 
-	// Propagate http request headers
+	// Propagate request metadata by adding them to outgoing http request headers
 	req.Header.Set(requestUUIDHeader, requestUUID)
 	req.Header.Set(clientNameHeader, c.observer.Name())
 

--- a/ohttp/server.go
+++ b/ohttp/server.go
@@ -123,6 +123,10 @@ func (m *Middleware) Wrap(next http.HandlerFunc) http.HandlerFunc {
 		// Get the name of client for the request if any
 		clientName := r.Header.Get(clientNameHeader)
 
+		// Propagate request metadata by adding them to outgoing http response headers
+		w.Header().Set(requestUUIDHeader, requestUUID)
+		w.Header().Set(clientNameHeader, clientName)
+
 		// Extract correlation context from the http headers
 		ctx = propagation.ExtractHTTP(ctx, global.Propagators(), r.Header)
 


### PR DESCRIPTION

## Description

  - [x] Resolves #62 
  - [x] `ohttp`: add request id and client name to response headers 
  - [x] `ogrpc`: add request id and client name to response metadata

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
